### PR TITLE
thêm chatGPT api

### DIFF
--- a/core/common/src/main/java/com/example/common/chatGPT/ChatGPTApi.kt
+++ b/core/common/src/main/java/com/example/common/chatGPT/ChatGPTApi.kt
@@ -1,0 +1,63 @@
+package com.example.common.chatGPT
+
+import com.google.gson.annotations.SerializedName
+import retrofit2.Call
+import retrofit2.http.Body
+import retrofit2.http.Headers
+import retrofit2.http.POST
+import java.io.Serializable
+
+interface ChatGPTApiService {
+    @Headers(
+        "Content-Type: application/json",
+        "Authorization: Bearer sk-proj-Uh3xe3T1rMTOJSpSnpdOT3BlbkFJsRqvfO5WSKWMlzW42bII"
+    )
+    @POST("v1/chat/completions")
+    fun chatWithGPT(
+        @Body request: ChatGPTRequest
+    ): Call<ChatGPTResponse>
+}
+
+data class ChatGPTRequest(
+    @SerializedName("model")
+    val model: String,
+    @SerializedName("messages")
+    val messages: List<Message>
+): Serializable {
+    override fun toString(): String {
+        return "ChatGPTRequest(model='$model', messages=${messages.joinToString(separator = "\n")})"
+    }
+}
+
+data class Message(
+    @SerializedName("role")
+    val role: String,
+    @SerializedName("content")
+    val content: String
+): Serializable {
+    override fun toString(): String {
+        return "Message(role='$role', content='$content')"
+    }
+}
+
+data class ChatGPTResponse(
+    @SerializedName("id")
+    val id: String,
+    @SerializedName("choices")
+    val choices: List<Choice>
+): Serializable {
+    override fun toString(): String {
+        return "ChatGPTResponse(id='$id', choices=${choices.joinToString(separator = "\n")})"
+    }
+}
+
+data class Choice(
+    @SerializedName("index")
+    val index: Int,
+    @SerializedName("message")
+    val message: Message
+): Serializable {
+    override fun toString(): String {
+        return "Choice(index= $index , message=$message)"
+    }
+}

--- a/core/common/src/main/java/com/example/common/chatGPT/chatGPTClient.kt
+++ b/core/common/src/main/java/com/example/common/chatGPT/chatGPTClient.kt
@@ -1,0 +1,61 @@
+package com.example.common.chatGPT
+
+import android.util.Log
+import androidx.compose.runtime.MutableState
+import okhttp3.OkHttpClient
+import retrofit2.Call
+import retrofit2.Callback
+import retrofit2.Response
+import retrofit2.Retrofit
+import retrofit2.converter.gson.GsonConverterFactory
+
+object ChatGPTClient {
+    //retrofit no care, care about function
+    private const val BASE_URL = "https://api.openai.com/"
+
+    private val retrofit: Retrofit by lazy {
+        Retrofit.Builder()
+            .baseUrl(BASE_URL)
+            .client(OkHttpClient.Builder().build())
+            .addConverterFactory(GsonConverterFactory.create())
+            .build()
+    }
+
+    private val chatGPTApi: ChatGPTApiService by lazy {
+        retrofit.create(ChatGPTApiService::class.java)
+    }
+
+    //remember the conversation since each api call is treat as single talk by gpt
+    val conversation: MutableList<Message> = mutableListOf()
+
+    fun chatWithGPT(chatMessage: String, nextStep: (Message) -> Unit) {
+        val message = Message(role = "user", content = chatMessage)
+        conversation.add(message)
+        val request = ChatGPTRequest(model = "gpt-3.5-turbo-16k", messages = conversation)
+
+        val call = chatGPTApi.chatWithGPT(request)
+        call.enqueue(object : Callback<ChatGPTResponse> {
+            override fun onResponse(call: Call<ChatGPTResponse>, response: Response<ChatGPTResponse>) {
+                if (response.isSuccessful) {
+                    val chatResponse = response.body()
+                    chatResponse?.choices?.firstOrNull()?.let {
+                        //add new message into conversation
+                        conversation.add(it.message)
+                        nextStep(it.message)
+                    }
+                    val reply = chatResponse?.choices?.firstOrNull()?.message?.content ?: "No response"
+                    Log.e("reply", reply)
+
+                } else {
+                    val reply = "Request failed with code: ${response.code()}"
+                    Log.e("reply", reply)
+                }
+            }
+
+            override fun onFailure(call: Call<ChatGPTResponse>, t: Throwable) {
+                val reply = "Request failed: ${t.message}"
+                Log.e("reply", reply)
+            }
+        })
+    }
+}


### PR DESCRIPTION
dùng chatGPT api cũng đơn giản thui, mình gửi message lên, nó response message về
### Cụ thể về request và response trong document của chatGPT api (này lướt qua thui)
Request:
```
curl https://api.openai.com/v1/chat/completions \
  -H "Content-Type: application/json" \
  -H "Authorization: Bearer $OPENAI_API_KEY" \
  -d '{
    "model": "gpt-3.5-turbo-16k",
    "messages": [
      {
        "role": "system",
        "content": "You are a helpful assistant."
      },
      {
        "role": "user",
        "content": "Hello!"
      }
    ]
  }'
```
Response:
```
{
  "id": "chatcmpl-123",
  "object": "chat.completion",
  "created": 1677652288,
  "model": "gpt-3.5-turbo-0125",
  "system_fingerprint": "fp_44709d6fcb",
  "choices": [{
    "index": 0,
    "message": {
      "role": "assistant",
      "content": "\n\nHello there, how may I assist you today?",
    },
    "logprobs": null,
    "finish_reason": "stop"
  }],
  "usage": {
    "prompt_tokens": 9,
    "completion_tokens": 12,
    "total_tokens": 21
  }
}
```
Trong code thì a dùng data class này để đại diện cho message
```
data class Message(
    @SerializedName("role")
    val role: String,
    @SerializedName("content")
    val content: String
)
```
role: để bên gpt api xem là message này của người dùng hay của bot. role assitant là của bot, role user là của người
content: message gửi cho nó thì lưu trong field này
### Lưu ý nhẹ
Mỗi lần gửi api thì bên đó coi là một lần chat riêng. Nếu muốn con bot nhớ conversation thì phải lưu cả message mình và message phản hồi của nó vào một list rồi cứ thể gửi lại, cập nhật list mỗi lần gọi api; chỉ cần thay đổi cái role kia là nó biết message nào của nó, của mình.
nếu muốn lưu đoạn hội thoại với con bot, chắc phải tạo một cái bảng riêng trong database chỉ để lưu message với chatGPT. Cái bảng chatGPTMessage sẽ có model như thế này chẳng hạn:
```
chatGPTMessage {
userId:   xem những message của đoạn hội thoại này của người dùng nào
timeStamp:    để sắp xếp message
role:  giải thích trên
content;    giải thích trên
}
```
Còn nếu mỗi lần đăng nhập app là chat lại với con bot từ đầu thì chẳng cần database XD. Quyết định làm tn bảo a để anh chỉnh lại code theo (chỉnh nhanh thôi)
### Cái cần quan tâm để dùng
a cho hết cái này vào package chatGPT trong core common
Lúc dùng thì dùng hàm này: 
```
chatWithGPT(chatMessage: String, nextStep: (Message) -> Unit)
```
cái hàm lambda là để đợi retrofit nhận phản hồi api thành công rồi xử lý tiếp
Trong cái object chatGPTClient a cũng lưu sẵn biến conversation: List<Message>, có thể load chat từ cái list này luôn ở hàm lambda truyền tiếp cho cái hàm này
### Nơi đặt con chat bot này trong app
a nghĩ có thể coi con bot này là một user, đặt trong cửa sổ chat riêng và sẽ luôn hiện ở đầu danh sách của người dùng? Load hội thoại của con bot này với người dùng chắc phải chỉnh lại tí tại model message dùng kiểu khác mà